### PR TITLE
Configure Dependabot for npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+assignees: 
+  - "SX-7"
+prefix: "[DEPBOT]"
+prefix-development: "[DEPBOT-DEV]"


### PR DESCRIPTION
Updated package ecosystem to 'npm' and added assignees and prefixes for Dependabot.